### PR TITLE
Fix client-side memory leak

### DIFF
--- a/src/main/java/zmaster587/libVulpes/util/InputSyncHandler.java
+++ b/src/main/java/zmaster587/libVulpes/util/InputSyncHandler.java
@@ -10,19 +10,18 @@ import zmaster587.libVulpes.api.IJetPack;
 import zmaster587.libVulpes.api.IModularArmor;
 
 import java.util.HashMap;
+import java.util.UUID;
 
 public class InputSyncHandler {
-
-	public static HashMap<EntityPlayer, Boolean> spaceDown = new HashMap<>();
-	
+	public static HashMap<UUID, Boolean> spaceDown = new HashMap<>();
 
 	public static boolean isSpaceDown(EntityPlayer player) {
-		Boolean bool = spaceDown.get(player);
+		Boolean bool = spaceDown.get(player.getUniqueID());
 		
 		return bool != null && bool;
 	}
 	
-	//Called on server
+	//Called on server (and client in AR KeyBindings class)
 	public static void updateKeyPress(EntityPlayer player, int key, boolean state) {
 		ItemStack stack;
 		switch(key) {
@@ -73,7 +72,7 @@ public class InputSyncHandler {
 			}
 			break;
 		case 57: //SPACE
-			spaceDown.put(player, state);
+			spaceDown.put(player.getUniqueID(), state);
 			break;
 			
 			default:
@@ -83,11 +82,11 @@ public class InputSyncHandler {
 	
 	@SubscribeEvent
 	public void onPlayerLoggedOut(PlayerLoggedOutEvent evt) {
-		spaceDown.remove(evt.player);
+		spaceDown.remove(evt.player.getUniqueID());
 	}
 
 	@SubscribeEvent
 	public void onDimChanged(PlayerChangedDimensionEvent evt) {
-		spaceDown.remove(evt.player);
+		spaceDown.remove(evt.player.getUniqueID());
 	}
 }


### PR DESCRIPTION
Changes `InputSyncHandler`'s key tracking map to use player UUID as keys instead. 

It turns out, this map is actually added to on the client side as well, not just the server, in Advanced Rocketry [here](https://github.com/Advanced-Rocketry/AdvancedRocketry/blob/c5cd5af62fc07cd4e0d24f06a16033f181c47c04/src/main/java/zmaster587/advancedRocketry/client/KeyBindings.java#L92), probably to handle the jetpack client-side correctly. As `PlayerLoggedOutEvent` and `PlayerChangedDimensionEvent` are only fired on the server, this means the map on the client-side (at the very least in an MP/dedicated server setting) will retain references to the client's player/`WorldClient`, and thus a memory leak. Using UUIDs to fix this is easier than listening to every client-side event necessary to clean up the map.

Easily reproducible if you have a client connect to a dedicated server. Have the client jump in several dimensions, then disconnect. The below heap dump is after doing this and sitting in the main menu; notice the `WorldClient` is retained when I am not in a world.
![ar_leak](https://github.com/user-attachments/assets/0b5f61d6-6046-4a87-8645-d0f938aa6580)